### PR TITLE
Add an update note API

### DIFF
--- a/mocks/update-event.json
+++ b/mocks/update-event.json
@@ -1,0 +1,11 @@
+{
+  "body": "{\"content\":\"new world\",\"attachment\":\"new.jpg\"}",
+  "pathParameters": {
+    "id": "82b64cf0-fe68-11e9-99b6-3d6b15ca2fc1"
+  },
+  "requestContext": {
+    "identity": {
+      "cognitoIdentityId": "USER-SUB-1234"
+    }
+  }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -51,9 +51,6 @@ functions:
           cors: true
           authorizer: aws_iam
   get:
-    # Defines an HTTP API endpoint that calls the main function in get.js
-    # - path: url path is /notes/{id}
-    # - method: GET request
     handler: get.main
     events:
       - http:
@@ -62,13 +59,18 @@ functions:
           cors: true
           authorizer: aws_iam
   list:
-    # Defines an HTTP API endpoint that calls the main function in list.js
-    # - path: url path is /notes
-    # - method: GET request
     handler: list.main
     events:
       - http:
           path: notes
           method: get
+          cors: true
+          authorizer: aws_iam
+  update:
+    handler: update.main
+    events:
+      - http:
+          path: notes/{id}
+          method: put
           cors: true
           authorizer: aws_iam

--- a/update.js
+++ b/update.js
@@ -1,0 +1,34 @@
+import * as dynamoDbLib from "./libs/dynamodb-lib";
+import { success, failure } from "./libs/response-lib";
+
+export async function main(event, context) {
+  const data = JSON.parse(event.body);
+  const params = {
+    TableName: process.env.tableName,
+    // 'Key' defines the partition key and sort key of the item to be updated
+    // - 'userId': Identity Pool identity id of the authenticated user
+    // - 'noteId': path parameter
+    Key: {
+      userId: event.requestContext.identity.cognitoIdentityId,
+      noteId: event.pathParameters.id
+    },
+    // 'UpdateExpression' defines the attributes to be updated
+    // 'ExpressionAttributeValues' defines the value in the update expression
+    UpdateExpression: "SET content = :content, attachment = :attachment",
+    ExpressionAttributeValues: {
+      ":attachment": data.attachment || null,
+      ":content": data.content || null
+    },
+    // 'ReturnValues' specifies if and how to return the item's attributes,
+    // where ALL_NEW returns all attributes of the item after the update; you
+    // can inspect 'result' below to see how it works with different settings
+    ReturnValues: "ALL_NEW"
+  };
+
+  try {
+    await dynamoDbLib.call("update", params);
+    return success({ status: true });
+  } catch (e) {
+    return failure({ status: false });
+  }
+}


### PR DESCRIPTION
This adds an API that allows a user to update
a note with a new note given its id.