### PR TITLE
Add handler for API Gateway CORS errors

### DIFF
--- a/resources/api-gateway-errors.yml
+++ b/resources/api-gateway-errors.yml
@@ -1,0 +1,19 @@
+Resources:
+  GatewayResponseDefault4XX:
+    Type: 'AWS::ApiGateway::GatewayResponse'
+    Properties:
+      ResponseParameters:
+         gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+         gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+      ResponseType: DEFAULT_4XX
+      RestApiId:
+        Ref: 'ApiGatewayRestApi'
+  GatewayResponseDefault5XX:
+    Type: 'AWS::ApiGateway::GatewayResponse'
+    Properties:
+      ResponseParameters:
+         gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+         gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+      ResponseType: DEFAULT_5XX
+      RestApiId:
+        Ref: 'ApiGatewayRestApi'

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,5 +1,10 @@
 service: notes-app-api
 
+# Create our resources with separate CloudFormation templates
+resources:
+  # API Gateway Errors
+  - ${file(resources/api-gateway-errors.yml)}
+
 # Create an optimized package for our functions
 package:
   individually: true


### PR DESCRIPTION
Configures API Gateway to set the CORS headers if
there is a HTTP error. When an API request is made
the API Gateway is invoked before our Lambda
functions and, in the case of an error, the CORS
headers will not be set.